### PR TITLE
상품 수정 api 구현 및 상품 dto 구조 변경

### DIFF
--- a/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/api/TicketController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/api/TicketController.java
@@ -1,13 +1,11 @@
 package com.samsam.travel.travelcommerce.domain.ticket.api;
 
 import com.samsam.travel.travelcommerce.domain.ticket.service.TicketService;
-import com.samsam.travel.travelcommerce.dto.TicketAddDto;
+import com.samsam.travel.travelcommerce.dto.ticket.TicketAddDto;
+import com.samsam.travel.travelcommerce.dto.ticket.TicketModifyDto;
 import com.samsam.travel.travelcommerce.utils.ReturnMessage;
 import jakarta.annotation.Resource;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/tickets")
@@ -19,5 +17,10 @@ public class TicketController {
     @PostMapping("/regist")
     public ReturnMessage addTicket(@ModelAttribute TicketAddDto ticketAddDto) {
         return new ReturnMessage(ticketService.addTicket(ticketAddDto));
+    }
+
+    @PutMapping("/modify")
+    public ReturnMessage updateTicket(@ModelAttribute TicketModifyDto ticketModifyDto) {
+        return new ReturnMessage(ticketService.updateTicket(ticketModifyDto));
     }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/repository/TicketRepository.java
@@ -2,6 +2,26 @@ package com.samsam.travel.travelcommerce.domain.ticket.repository;
 
 import com.samsam.travel.travelcommerce.dao.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    @Modifying
+    @Transactional
+    @Query(
+            "UPDATE Ticket t " +
+            "SET " +
+                "t.title        =   :#{#ticket.title}, " +
+                "t.contents     =   :#{#ticket.contents}, " +
+                "t.place        =   :#{#ticket.place}, " +
+                "t.price        =   :#{#ticket.price}, " +
+                "t.startDate    =   :#{#ticket.startDate}, " +
+                "t.endDate      =   :#{#ticket.endDate} " +
+            "WHERE t.ticketId   =   :#{#ticket.ticketId} " +
+            "AND t.user.userId  =   :#{#ticket.user.userId}"
+    )
+    int updateTicket(@Param("ticket") Ticket ticket);
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/service/TicketService.java
@@ -1,8 +1,11 @@
 package com.samsam.travel.travelcommerce.domain.ticket.service;
 
-import com.samsam.travel.travelcommerce.dto.TicketAddDto;
+import com.samsam.travel.travelcommerce.dto.ticket.TicketAddDto;
+import com.samsam.travel.travelcommerce.dto.ticket.TicketModifyDto;
 
 public interface TicketService {
 
     public Object addTicket(TicketAddDto ticketAddDto);
+
+    public Object updateTicket(TicketModifyDto ticketModifyDto);
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/service/TicketServiceImpl.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/service/TicketServiceImpl.java
@@ -3,7 +3,8 @@ package com.samsam.travel.travelcommerce.domain.ticket.service;
 import com.samsam.travel.travelcommerce.dao.Ticket;
 import com.samsam.travel.travelcommerce.dao.User;
 import com.samsam.travel.travelcommerce.domain.ticket.repository.TicketRepository;
-import com.samsam.travel.travelcommerce.dto.TicketAddDto;
+import com.samsam.travel.travelcommerce.dto.ticket.TicketAddDto;
+import com.samsam.travel.travelcommerce.dto.ticket.TicketModifyDto;
 import com.samsam.travel.travelcommerce.utils.Common;
 import jakarta.annotation.Resource;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,25 @@ public class TicketServiceImpl implements TicketService {
                 .build();
 
         return repository.save(ticket);
+    }
+    public Object updateTicket(TicketModifyDto ticketModifyDto) {
+        User user = new User()
+                .builder()
+                .userId("test")
+                .build();
+
+        Ticket ticket = new Ticket().builder()
+                .ticketId(ticketModifyDto.getTicketId())
+                .user(user)
+                .title(ticketModifyDto.getTitle())
+                .contents(ticketModifyDto.getContents())
+                .place(ticketModifyDto.getPlace())
+                .price(ticketModifyDto.getPrice())
+                .startDate(ticketModifyDto.getStartDate())
+                .endDate(ticketModifyDto.getEndDate())
+                .build();
+
+        return repository.updateTicket(ticket);
     }
 
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/dto/ticket/TicketAddDto.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/dto/ticket/TicketAddDto.java
@@ -1,4 +1,4 @@
-package com.samsam.travel.travelcommerce.dto;
+package com.samsam.travel.travelcommerce.dto.ticket;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/samsam/travel/travelcommerce/dto/ticket/TicketModifyDto.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/dto/ticket/TicketModifyDto.java
@@ -1,0 +1,20 @@
+package com.samsam.travel.travelcommerce.dto.ticket;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class TicketModifyDto {
+    private String ticketId;
+    private String title;
+    private String contents;
+    private String place;
+    private int price;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}


### PR DESCRIPTION
설명
이 PR은 TravelCommerce 애플리케이션의 상품 수정 api를 추가했습니다.
상품 수정에 필요한 로직 생성 및 기존 dto 패키지를 수정하고 postman을 통해 테스트 하였습니다.

포함된 변경 사항
생성
TicketModifyDto : 수정 시 사용되는 Dto 생성

수정
TicketAddDto : 패키지 구조 변경
TicketController : 상품 수정에 대한 로직 추가
TicketService : 상품 수정에 대한 로직 추가
TicketServiceImpl : 상품 수정에 대한 로직 추가
TicketRepository : 상품 수정에 대한 로직 추가(커스텀 해서 사용)

주의 사항
gradle에서 starter-security 주석 후 테스트

리뷰 요청 사항
로직 확인 및 테스트 요청 드립니다!