### PR TITLE
관리자 전체 유저 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
@@ -1,0 +1,47 @@
+package com.samsam.travel.travelcommerce.domain.user.api;
+
+import com.samsam.travel.travelcommerce.domain.user.service.AdminService;
+import com.samsam.travel.travelcommerce.dto.user.UserInfoResponse;
+import com.samsam.travel.travelcommerce.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_ALL_USER_INFO;
+
+/**
+ * 이 컨트롤러는 관리자 관련 API를 처리하는 컨트롤러입니다.
+ *
+ * @author lavin
+ * @since 1.0
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    /**
+     * 모든 사용자 정보를 가져옵니다.
+     *
+     * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+     * @return ResponseEntity에 ApiResponse를 포함하고 있는 ResponseEntity.
+     *         ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 모든 사용자 정보가 있습니다.
+     */
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<List<UserInfoResponse>>> fetchAllUsers(@AuthenticationPrincipal UserDetails userDetails) {
+        log.info("getAllUserInfo called by {}", userDetails.getUsername());
+        List<UserInfoResponse> userInfoResponses = adminService.getAllUserInfo(userDetails.getUsername());
+        ApiResponse<List<UserInfoResponse>> response = ApiResponse.createResponse(SUCCESS_ALL_USER_INFO, userInfoResponses);
+        return ResponseEntity.status(SUCCESS_ALL_USER_INFO.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/repository/UserRepository.java
@@ -1,7 +1,18 @@
 package com.samsam.travel.travelcommerce.domain.user.repository;
 
 import com.samsam.travel.travelcommerce.entity.User;
+import com.samsam.travel.travelcommerce.entity.model.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, String> {
+
+    /**
+     * 사용자 ID로 역할을 찾아 반환합니다.
+     *
+     * @param userId 사용자 ID.
+     * @return 사용자 ID에 해당하는 역할.
+     */
+    @Query("select u.role from User u where u.userId = ?1")
+    Role findRoleByUserId(String userId);
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/service/AdminService.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/service/AdminService.java
@@ -1,0 +1,45 @@
+package com.samsam.travel.travelcommerce.domain.user.service;
+
+import com.samsam.travel.travelcommerce.domain.user.repository.UserRepository;
+import com.samsam.travel.travelcommerce.dto.user.UserInfoResponse;
+import com.samsam.travel.travelcommerce.entity.model.Role;
+import com.samsam.travel.travelcommerce.global.error.exception.UserUnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.samsam.travel.travelcommerce.global.status.ErrorCode.USER_NOT_MASTER;
+
+/**
+ * 이 서비스 클래스는 관리자 기능을 제공합니다.
+ *
+ * @author lavin
+ * @since 1.0
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    /**
+     * 사용자 저장소 인터페이스. 데이터베이스 작업을 위해 사용됩니다.
+     */
+    private final UserRepository userRepository;
+
+    /**
+     * 모든 사용자 정보를 가져옵니다.
+     *
+     * @param userId 인증된 관리자의 사용자 ID.
+     * @return 모든 사용자 정보를 포함하는 UserInfoResponse 목록.
+     * @throws UserUnauthorizedException 사용자가 관리자가 아닌 경우 발생합니다.
+     */
+    public List<UserInfoResponse> getAllUserInfo(String userId) {
+        if(!userRepository.findRoleByUserId(userId).equals(Role.MASTER)){
+            throw new UserUnauthorizedException(USER_NOT_MASTER);
+        }
+        return userRepository.findAll()
+                .stream()
+                .map(user -> user.toUserInfoResponse())
+                .toList();
+    }
+}

--- a/src/main/java/com/samsam/travel/travelcommerce/dto/user/UserInfoResponse.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/dto/user/UserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.samsam.travel.travelcommerce.dto.user;
+
+import com.samsam.travel.travelcommerce.entity.model.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 회원 정보 반환 dto
+ */
+@Getter
+@Builder
+public class UserInfoResponse {
+    private final String id;
+    private final String name;
+    private final String phone;
+    private final Role role;
+}

--- a/src/main/java/com/samsam/travel/travelcommerce/entity/User.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/entity/User.java
@@ -1,5 +1,6 @@
 package com.samsam.travel.travelcommerce.entity;
 
+import com.samsam.travel.travelcommerce.dto.user.UserInfoResponse;
 import com.samsam.travel.travelcommerce.entity.model.Role;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -57,4 +58,18 @@ public class User {
         return Objects.hash(userId);
     }
 
+    /**
+     * 현재 User 엔티티를 UserInfoResponse 객체로 변환합니다.
+     * 이 메서드는 외부 시스템이나 클라이언트에게 User 엔티티의 간단한 표현을 제공하기 위해 사용됩니다.
+     *
+     * @return UserInfoResponse 객체.
+     */
+    public UserInfoResponse toUserInfoResponse() {
+        return UserInfoResponse.builder()
+                .id(this.userId)
+                .name(this.name)
+                .phone(this.phone)
+                .role(this.role)
+                .build();
+    }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/global/error/exception/UserUnauthorizedException.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/global/error/exception/UserUnauthorizedException.java
@@ -1,0 +1,19 @@
+package com.samsam.travel.travelcommerce.global.error.exception;
+
+import com.samsam.travel.travelcommerce.global.status.ErrorCode;
+
+/**
+ * 사용자가 권한이 없을 때 발생하는 예외 클래스.
+ * BusinessException을 확장합니다.
+ */
+public class UserUnauthorizedException extends BusinessException {
+
+    /**
+     * 지정된 오류 코드로 새 UserUnauthorizedException 생성합니다.
+     *
+     * @param errorCode 이 예외와 관련된 특정 오류 코드.
+     */
+    public UserUnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/samsam/travel/travelcommerce/global/status/ErrorCode.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/global/status/ErrorCode.java
@@ -37,6 +37,11 @@ public enum ErrorCode {
     NO_AUTH(HttpStatus.FORBIDDEN, "4030", "권한이 없는 유저입니다."),
 
     /**
+     * 마스터 관리자만 접속할 수 있는 것을 나타내는 에러 코드
+     */
+    USER_NOT_MASTER(HttpStatus.FORBIDDEN, "4033", "마스터 관리자만 접속할 수 있습니다."),
+
+    /**
      * id가 중복된 것을 나타내는 에러 코드.
      */
     USER_ID_DUPLICATE(HttpStatus.NOT_ACCEPTABLE, "4060", "id가 중복되었습니다."),

--- a/src/main/java/com/samsam/travel/travelcommerce/security/config/SecurityConfig.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/security/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger*/**").permitAll()
                         .requestMatchers("/auth/**").permitAll() // auth로 시작하는 URI는 인증 없이 접근 가능
                         .requestMatchers("/api/master/**").hasAuthority(Role.MASTER.toString()) // /api/master/**는 MASTER 권한이 있는 사용자만 접근 가능
-                        .requestMatchers("/api/admin/**").hasAnyRole(Role.ADMIN.toString(), Role.MASTER.toString()) // /api/admin/**는 ADMIN 또는 MASTER 권한이 있는 사용자만 접근 가능
+                        .requestMatchers("/api/admin/**").hasAnyAuthority(Role.ADMIN.toString(), Role.MASTER.toString()) // /api/admin/**는 ADMIN 또는 MASTER 권한이 있는 사용자만 접근 가능
                         .requestMatchers("/api/**").authenticated() // /api/**로 시작하는 모든 URI는 인증 필요
                         .anyRequest().authenticated() // 그 외의 모든 요청은 인증 필요
                 )


### PR DESCRIPTION
### 설명
이 PR은 관리자 유저의 전체 유저 정보 조회 기능을 도입합니다.

### 포함된 변경 사항
- UserRepository에서 사용자 ID로 역할을 찾아 반환하는 메소드 추가
  - Role findRoleByUserId(String userId);
- 권한 없음 관련 예외 클래스 생성 
  - UserUnauthorizedException
- 마스터 관리자만 접속할 수 있는 것을 나타내는 에러 코드 추가
  - USER_NOT_MASTER(HttpStatus.FORBIDDEN, "4033", "마스터 관리자만 접속할 수 있습니다."),
- Spring Security 설정 변경 
  - 기존 hasAnyRole 사용 시 권한이 있어도 접근이 불가한 이슈가 발생하여 hasAnyAuthority로 변경
- 유저 정보 조회 기능 Controller, Service 구현
  -  관리자와 관련된 비즈니스 로직을 분리하기 위해 별도의 AdminController, AdminService 생성
### 리뷰 요청 사항
- 전체적인 프로젝트 구조 확인 및 테스트 후 피드백 부탁드립니다!