### PR TITLE
응답 생성 로직의 중복을 제거를 위해 ResponseUtil 도입

### DIFF
--- a/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/api/TicketController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/ticket/api/TicketController.java
@@ -15,6 +15,13 @@ import org.springframework.web.bind.annotation.*;
 import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_ADD_TICKET;
 import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_MODIFY_TICKET;
 
+/**
+ * 상품(티켓)에 관련된 API를 수행하는 컨트롤러입니다.
+ *
+ * @author colton
+ * @since 1.0.0
+ */
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/tickets")
@@ -22,6 +29,13 @@ public class TicketController {
 
     private final TicketService ticketService;
 
+    /**
+     * 상품 등록 API
+     *
+     * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+     * @param ticketDto 상품에 대한 정보
+     * @return 상품 등록 성공 여부, 문구와 상품 데이터
+     */
     @PostMapping("/regist")
     public ResponseEntity<ApiResponse<TicketResponseDto>> addTicket(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute TicketDto ticketDto) {
         setTicketDto(userDetails, ticketDto);
@@ -29,6 +43,13 @@ public class TicketController {
         return buildResponseEntity(SUCCESS_ADD_TICKET, responseDto);
     }
 
+    /**
+     * 상품 수정 API
+     *
+     * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+     * @param ticketDto 상품에 대한 정보
+     * @return 상품 수정 여부, 문구와 상품 데이터
+     */
     @PutMapping("/modify")
     public ResponseEntity<ApiResponse<Boolean>> updateTicket(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute TicketDto ticketDto) {
         setTicketDto(userDetails, ticketDto);
@@ -36,16 +57,36 @@ public class TicketController {
         return buildResponseEntity(SUCCESS_MODIFY_TICKET, updateYn);
     }
 
+    /**
+     * ResposeEntity 생성 메서드
+     *
+     * @param code 상태 코드와 해당 메시지 담고 있는 부분
+     * @param data 데이터를 담고 있는 부분
+     * @return 상태 코드와 메시지, 데이트를 담고 있는 ResponseEntity
+     */
     private <T> ResponseEntity<ApiResponse<T>> buildResponseEntity(CommonCode code, T data) {
         ApiResponse<T> response = ApiResponse.createResponse(code, data);
         return ResponseEntity.status(code.getHttpStatus()).body(response);
     }
 
+    /**
+     * Respose
+     *
+     * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+     * @param ticketDto 상품에 대한 정보
+     * @return 상품 수정 여부, 문구와 상품 데이터
+     */
     public TicketDto setTicketDto(UserDetails userDetails, TicketDto ticketDto) {
         ticketDto.setUser(getUser(userDetails));
         return ticketDto;
     }
 
+    /**
+     * 유저 정보를 User Entity에 담는 메서드
+     *
+     * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+     * @return User 정보를 담은 user Entity 반환
+     */
     public User getUser(UserDetails userDetails) {
         return  User
                 .builder()

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
@@ -16,8 +16,9 @@ import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_
 import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_ASSIGN_ROLE;
 
 /**
- * 이 컨트롤러는 관리자 관련 API를 처리하는 컨트롤러입니다.
+ * 관리자 관련 API 요청을 처리하는 컨트롤러입니다.
  *
+ * @author lavin
  * @since 1.0
  */
 @RestController
@@ -41,19 +42,18 @@ public class AdminController {
     }
 
     /**
- * 지정된 사용자에게 새로운 역할을 할당합니다.
- *
- * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
- * @param userId       역할을 할당할 사용자 ID.
- * @param newRole      새로운 역할.
- * @return ResponseEntity<ApiResponse>에 ApiResponse를 포함하고 있는 ResponseEntity.
- *         ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 성공 메시지가 있습니다.
- */
-@PutMapping("/users/{userId}/role")
-public ResponseEntity<ApiResponse> assignRoleToUser(@AuthenticationPrincipal UserDetails userDetails, @PathVariable String userId, @RequestParam String newRole) {
-    adminService.updateUserRole(userId, newRole, userDetails.getUsername());
-    String formattedMessage = String.format(SUCCESS_ASSIGN_ROLE.getMessage(), userId, newRole);
-    ApiResponse response = ApiResponse.createResponse(SUCCESS_ASSIGN_ROLE, formattedMessage);
-    return ResponseEntity.status(SUCCESS_ASSIGN_ROLE.getHttpStatus()).body(response);
-}
+     * 지정된 사용자에게 새로운 역할을 할당합니다.
+     *
+     * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+     * @param userId       역할을 할당할 사용자 ID.
+     * @param newRole      새로운 역할.
+     * @return ResponseEntity<ApiResponse>에 ApiResponse를 포함하고 있는 ResponseEntity. ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 성공 메시지가 있습니다.
+     * @since 1.0
+     */
+    @PutMapping("/users/{userId}/role")
+    public ResponseEntity<ApiResponse> assignRoleToUser(@AuthenticationPrincipal UserDetails userDetails, @PathVariable String userId, @RequestParam String newRole) {
+        adminService.updateUserRole(userId, newRole, userDetails.getUsername());
+        String formattedMessage = String.format(SUCCESS_ASSIGN_ROLE.getMessage(), userId, newRole);
+        return ResponseUtil.createApiResponse(SUCCESS_ASSIGN_ROLE, formattedMessage);
+    }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
@@ -5,24 +5,21 @@ import com.samsam.travel.travelcommerce.dto.user.UserInfoResponse;
 import com.samsam.travel.travelcommerce.utils.ApiResponse;
 import com.samsam.travel.travelcommerce.utils.ResponseUtil;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_ALL_USER_INFO;
+import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_ASSIGN_ROLE;
 
 /**
  * 이 컨트롤러는 관리자 관련 API를 처리하는 컨트롤러입니다.
  *
  * @since 1.0
  */
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
@@ -39,8 +36,24 @@ public class AdminController {
      */
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<List<UserInfoResponse>>> fetchAllUsers(@AuthenticationPrincipal UserDetails userDetails) {
-        log.info("getAllUserInfo called by {}", userDetails.getUsername());
         List<UserInfoResponse> userInfoResponses = adminService.getAllUserInfo(userDetails.getUsername());
         return ResponseUtil.createApiResponse(SUCCESS_ALL_USER_INFO, userInfoResponses);
     }
+
+    /**
+ * 지정된 사용자에게 새로운 역할을 할당합니다.
+ *
+ * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
+ * @param userId       역할을 할당할 사용자 ID.
+ * @param newRole      새로운 역할.
+ * @return ResponseEntity<ApiResponse>에 ApiResponse를 포함하고 있는 ResponseEntity.
+ *         ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 성공 메시지가 있습니다.
+ */
+@PutMapping("/users/{userId}/role")
+public ResponseEntity<ApiResponse> assignRoleToUser(@AuthenticationPrincipal UserDetails userDetails, @PathVariable String userId, @RequestParam String newRole) {
+    adminService.updateUserRole(userId, newRole, userDetails.getUsername());
+    String formattedMessage = String.format(SUCCESS_ASSIGN_ROLE.getMessage(), userId, newRole);
+    ApiResponse response = ApiResponse.createResponse(SUCCESS_ASSIGN_ROLE, formattedMessage);
+    return ResponseEntity.status(SUCCESS_ASSIGN_ROLE.getHttpStatus()).body(response);
+}
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AdminController.java
@@ -3,6 +3,7 @@ package com.samsam.travel.travelcommerce.domain.user.api;
 import com.samsam.travel.travelcommerce.domain.user.service.AdminService;
 import com.samsam.travel.travelcommerce.dto.user.UserInfoResponse;
 import com.samsam.travel.travelcommerce.utils.ApiResponse;
+import com.samsam.travel.travelcommerce.utils.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,6 @@ import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_
 /**
  * 이 컨트롤러는 관리자 관련 API를 처리하는 컨트롤러입니다.
  *
- * @author lavin
  * @since 1.0
  */
 @Slf4j
@@ -34,14 +34,13 @@ public class AdminController {
      * 모든 사용자 정보를 가져옵니다.
      *
      * @param userDetails 인증된 관리자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
-     * @return ResponseEntity에 ApiResponse를 포함하고 있는 ResponseEntity.
-     *         ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 모든 사용자 정보가 있습니다.
+     * @return ResponseEntity에 ApiResponse를 포함하고 있는 ResponseEntity. ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 모든 사용자 정보가 있습니다.
+     * @since 1.0
      */
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<List<UserInfoResponse>>> fetchAllUsers(@AuthenticationPrincipal UserDetails userDetails) {
         log.info("getAllUserInfo called by {}", userDetails.getUsername());
         List<UserInfoResponse> userInfoResponses = adminService.getAllUserInfo(userDetails.getUsername());
-        ApiResponse<List<UserInfoResponse>> response = ApiResponse.createResponse(SUCCESS_ALL_USER_INFO, userInfoResponses);
-        return ResponseEntity.status(SUCCESS_ALL_USER_INFO.getHttpStatus()).body(response);
+        return ResponseUtil.createApiResponse(SUCCESS_ALL_USER_INFO, userInfoResponses);
     }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AuthController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/AuthController.java
@@ -5,6 +5,7 @@ import com.samsam.travel.travelcommerce.dto.user.LoginRequest;
 import com.samsam.travel.travelcommerce.dto.user.LoginResponse;
 import com.samsam.travel.travelcommerce.dto.user.SignUpRequest;
 import com.samsam.travel.travelcommerce.utils.ApiResponse;
+import com.samsam.travel.travelcommerce.utils.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,9 +26,7 @@ import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
-    /**
-     * 사용자 인증 서비스
-     */
+
     private final UserAuthService userAuthService;
 
     /**
@@ -39,8 +38,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest loginRequest) {
         LoginResponse loginResponse = userAuthService.login(loginRequest);
-        ApiResponse<LoginResponse> response = ApiResponse.createResponse(SUCCESS_LOGIN, loginResponse);
-        return ResponseEntity.status(SUCCESS_LOGIN.getHttpStatus()).body(response);
+        return ResponseUtil.createApiResponse(SUCCESS_LOGIN, loginResponse);
     }
 
     /**
@@ -57,7 +55,6 @@ public class AuthController {
     public ResponseEntity<ApiResponse> signUp(@RequestBody SignUpRequest signUpRequest) {
         userAuthService.signUp(signUpRequest);
         String formattedMessage = String.format(SUCCESS_SIGN_UP.getMessage(), signUpRequest.getId());
-        ApiResponse response = ApiResponse.createResponse(SUCCESS_SIGN_UP, formattedMessage);
-        return ResponseEntity.status(SUCCESS_SIGN_UP.getHttpStatus()).body(response);
+        return ResponseUtil.createApiResponse(SUCCESS_SIGN_UP, formattedMessage);
     }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/UserController.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/api/UserController.java
@@ -3,6 +3,7 @@ package com.samsam.travel.travelcommerce.domain.user.api;
 import com.samsam.travel.travelcommerce.domain.user.service.UserService;
 import com.samsam.travel.travelcommerce.dto.user.UserInfoResponse;
 import com.samsam.travel.travelcommerce.utils.ApiResponse;
+import com.samsam.travel.travelcommerce.utils.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,8 +17,7 @@ import static com.samsam.travel.travelcommerce.global.status.CommonCode.SUCCESS_
 /**
  * 이 컨트롤러는 사용자 관련 API를 처리하는 컨트롤러입니다.
  *
- *  * @author lavin
- *  * @since 1.0
+ * @since 1.0
  */
 @RestController
 @RequiredArgsConstructor
@@ -30,13 +30,12 @@ public class UserController {
      * 인증된 사용자에 따라 사용자 정보를 검색합니다.
      *
      * @param userDetails 인증된 사용자의 세부 정보. Spring Security 컨텍스트에서 가져옵니다.
-     * @return ResponseEntity에 ApiResponse를 포함하고 있는 ResponseEntity.
-     *         ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 사용자 정보가 있습니다.
+     * @return ResponseEntity에 ApiResponse를 포함하고 있는 ResponseEntity. ApiResponse에는 상태 코드 200(OK)이 있으며, data 필드에 사용자 정보가 있습니다.
+     * @since 1.0
      */
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(@AuthenticationPrincipal UserDetails userDetails) {
         UserInfoResponse userInfo = userService.getUserInfo(userDetails.getUsername());
-        ApiResponse<UserInfoResponse> response = ApiResponse.createResponse(SUCCESS_USER_INFO, userInfo);
-        return ResponseEntity.status(SUCCESS_USER_INFO.getHttpStatus()).body(response);
+        return ResponseUtil.createApiResponse(SUCCESS_USER_INFO, userInfo);
     }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/repository/UserRepository.java
@@ -3,7 +3,9 @@ package com.samsam.travel.travelcommerce.domain.user.repository;
 import com.samsam.travel.travelcommerce.entity.User;
 import com.samsam.travel.travelcommerce.entity.model.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface UserRepository extends JpaRepository<User, String> {
 
@@ -15,4 +17,17 @@ public interface UserRepository extends JpaRepository<User, String> {
      */
     @Query("select u.role from User u where u.userId = ?1")
     Role findRoleByUserId(String userId);
+
+    /**
+     * 사용자 ID를 기반으로 데이터베이스에서 사용자의 역할을 업데이트합니다.
+     *
+     * @param role   새로운 역할로 사용자에게 할당할 역할.
+     * @param userId 업데이트할 사용자의 ID.
+     * @return 업데이트된 행의 수.
+     *         성공적으로 업데이트된 경우 1, 실패한 경우 0 이상.
+     */
+    @Transactional
+    @Modifying
+    @Query("update User u set u.role = ?1 where u.userId = ?2")
+    int updateRoleByUserId(Role role, String userId);
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/domain/user/service/AdminService.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/domain/user/service/AdminService.java
@@ -29,17 +29,42 @@ public class AdminService {
     /**
      * 모든 사용자 정보를 가져옵니다.
      *
-     * @param userId 인증된 관리자의 사용자 ID.
+     * @param adminId 인증된 관리자의 사용자 ID.
      * @return 모든 사용자 정보를 포함하는 UserInfoResponse 목록.
      * @throws UserUnauthorizedException 사용자가 관리자가 아닌 경우 발생합니다.
      */
-    public List<UserInfoResponse> getAllUserInfo(String userId) {
-        if(!userRepository.findRoleByUserId(userId).equals(Role.MASTER)){
-            throw new UserUnauthorizedException(USER_NOT_MASTER);
-        }
+    public List<UserInfoResponse> getAllUserInfo(String adminId) {
+        validateMasterRole(adminId);
+
         return userRepository.findAll()
                 .stream()
                 .map(user -> user.toUserInfoResponse())
                 .toList();
+    }
+
+    /**
+     * 사용자 역할을 업데이트합니다.
+     *
+     * @param userId  역할을 업데이트할 사용자 ID.
+     * @param newRole 새로운 역할.
+     * @param adminId 인증된 관리자의 사용자 ID.
+     * @throws UserUnauthorizedException 사용자가 관리자가 아닌 경우 발생합니다.
+     */
+    public void updateUserRole(String userId, String newRole, String adminId) {
+        validateMasterRole(adminId);
+    
+        userRepository.updateRoleByUserId(Role.valueOf(newRole), userId);
+    }
+
+    /**
+     * 관리자 역할을 확인합니다.
+     *
+     * @param adminId 인증된 관리자의 사용자 ID.
+     * @throws UserUnauthorizedException 사용자가 관리자가 아닌 경우 발생합니다.
+     */
+    private void validateMasterRole(String adminId) {
+        if(!userRepository.findRoleByUserId(adminId).equals(Role.MASTER)){
+            throw new UserUnauthorizedException(USER_NOT_MASTER);
+        }
     }
 }

--- a/src/main/java/com/samsam/travel/travelcommerce/global/status/CommonCode.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/global/status/CommonCode.java
@@ -49,6 +49,12 @@ public enum CommonCode {
     SUCCESS_DEPRIVATION(HttpStatus.OK, "2005", "%s 계정에 관리자 권한이 박탈됐습니다."),
 
     /**
+     * 역할 할당 성공 상태를 나타내는 상태 코드.
+     * %s는 아이디, 변경된 권한으로 대체됩니다.
+     */
+    SUCCESS_ASSIGN_ROLE(HttpStatus.OK, "2006", "%s 계정의 권한이 %s로 변경되었습니다."),
+
+    /**
      * 상품 등록이 성공적으로 등록되었음을 나타내는 상태 코드.
      */
     SUCCESS_ADD_TICKET(HttpStatus.OK, "2100", "상품이 등록 되었습니다."),
@@ -57,6 +63,7 @@ public enum CommonCode {
      * 상품 수정이 성공적으로 수정되었음을 나타내는 상태 코드.
      */
     SUCCESS_MODIFY_TICKET(HttpStatus.OK, "2101", "상품이 수정 되었습니다."),
+
 
     ;
 

--- a/src/main/java/com/samsam/travel/travelcommerce/utils/ResponseUtil.java
+++ b/src/main/java/com/samsam/travel/travelcommerce/utils/ResponseUtil.java
@@ -1,0 +1,35 @@
+package com.samsam.travel.travelcommerce.utils;
+
+import com.samsam.travel.travelcommerce.global.status.CommonCode;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * API 응답을 생성하기 위한 유틸리티 클래스입니다.
+ */
+public class ResponseUtil {
+
+    /**
+     * 지정된 상태 코드와 데이터를 사용하여 API 응답을 생성합니다.
+     *
+     * @param <T>       응답에 포함할 데이터의 유형.
+     * @param code      API 응답에 포함할 상태 코드.
+     * @param data      API 응답에 포함할 데이터.
+     * @return ResponseEntity<ApiResponse<T>> API 응답.
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> createApiResponse(CommonCode code, T data) {
+        ApiResponse<T> response = ApiResponse.createResponse(code, data);
+        return ResponseEntity.status(code.getHttpStatus()).body(response);
+    }
+
+    /**
+     * 지정된 상태 코드와 메시지를 사용하여 API 응답을 생성합니다.
+     *
+     * @param code      API 응답에 포함할 상태 코드.
+     * @param message   API 응답에 포함할 메시지.
+     * @return ResponseEntity<ApiResponse> API 응답.
+     */
+    public static ResponseEntity<ApiResponse> createApiResponse(CommonCode code, String message) {
+        ApiResponse response = ApiResponse.createResponse(code, message);
+        return ResponseEntity.status(code.getHttpStatus()).body(response);
+    }
+}

--- a/src/test/java/com/samsam/travel/travelcommerce/AdminServiceTest.java
+++ b/src/test/java/com/samsam/travel/travelcommerce/AdminServiceTest.java
@@ -1,0 +1,41 @@
+package com.samsam.travel.travelcommerce;
+
+import com.samsam.travel.travelcommerce.domain.user.repository.UserRepository;
+import com.samsam.travel.travelcommerce.domain.user.service.AdminService;
+import com.samsam.travel.travelcommerce.entity.model.Role;
+import com.samsam.travel.travelcommerce.global.error.exception.UserUnauthorizedException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static com.samsam.travel.travelcommerce.global.status.ErrorCode.USER_NOT_MASTER;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class AdminServiceTest {
+
+    @Autowired
+    private AdminService adminService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void updateUserRole_shouldThrowUserUnauthorizedException_whenAdminIdIsNotMasterRole() {
+        // given
+        String userId = "testUserId";
+        String newRole = "ADMIN";
+        String adminId = "nonMasterAdminId";
+
+        when(userRepository.findRoleByUserId(adminId)).thenReturn(Role.NORMAL);
+
+        // when
+        Throwable exception = assertThrows(UserUnauthorizedException.class, () -> adminService.updateUserRole(userId, newRole, adminId));
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo(USER_NOT_MASTER.getMessage());
+    }
+}


### PR DESCRIPTION
### 설명
이 PR은 응답 생성 로직의 중복을 제거를 위해 ResponseUtil 도입합니다.
ResponseUtil 클래스를 도입하여 ApiResponse와 ResponseEntity 생성 로직을 공통화하였습니다.


### 포함된 변경 사항
- ResponseUtil 클래스 생성
- UserController, AdminController, AuthController 클래스에서 중복된 응답 생성 코드를 ResponseUtil을 통해 대체하였습니다.

### 리뷰 요청 사항
- ResponseUtil 클래스 확인 및 테스트 후 피드백 부탁드립니다!